### PR TITLE
Fix caption rendering on Windows: escape colon in drawtext fontfile path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -874,7 +874,7 @@ fn build_drawtext_filters(
         let mut font_option = String::new();
         for path in &font_paths {
             if std::path::Path::new(path).exists() {
-                font_option = format!("fontfile='{}':", path);
+                font_option = format!("fontfile='{}':", path.replace(':', "\:"));
                 break;
             }
         }


### PR DESCRIPTION
On Windows the caption font path (e.g. C:/Windows/Fonts/SegoeUIb.ttf) was wrapped in single quotes only. FFmpeg's filtergraph parser strips those quotes before drawtext parses its own options, so the colon in the drive letter is treated as a drawtext option separator, causing "No option name near '/Windows/...'" and skipping all captions. Escaping the colon (\:) lets the path survive drawtext's option parser. No-op for macOS/Linux paths, which contain no colon. Surfaced on FFmpeg 8.x whose stricter parser fails hard.