### PR TITLE
feat: add OpenAI and Gemini LLM providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ DEEPGRAM_API_KEY=your_deepgram_key_here
 ANTHROPIC_API_KEY=your_anthropic_key_here
 LLM_PROVIDER=deepseek
 DEEPSEEK_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 dist
+bun.lock
+src-tauri/gen/schemas/*
+package-lock.json
 target
 src-tauri/target
 .env

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository implements the desktop app foundation using **Tauri 2 + React + 
 
 ## Key Features
 
-- **Dynamic Multi-LLM Support**: Supports both **DeepSeek** (default) and **Claude** (anthropic) for viral moment detection and hooks analysis.
+- **Dynamic Multi-LLM Support**: Supports **DeepSeek** (default), **Claude** (anthropic), **OpenAI**, and **Google Gemini** for cloud-based viral moment detection and hooks analysis, plus **Ollama** for fully-local inference. Pick your provider and model in API Settings.
 - **Automated Pipeline**: Imports media, extracts audio, transcribes using Deepgram, and automatically analyzes and ranks moments in a single automated chain.
 - **Local SQLite Storage**: Saves transcripts, candidates, custom names, and rendering data locally.
 - **Native Project Manager**: Create, open, rename, and delete projects from the dashboard.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -483,7 +483,7 @@ async fn generate_candidates(
                 .ok_or_else(|| "Set GEMINI_API_KEY or supply Gemini API Key to generate candidates.".to_string())?;
             let model = model_name
                 .or_else(|| std::env::var("GEMINI_MODEL").ok())
-                .unwrap_or_else(|| "gemini-1.5-flash".to_string());
+                .unwrap_or_else(|| "gemini-2.5-flash".to_string());
             llm::detect_candidates_with_gemini(&normalized, &key, &model)
                 .await
                 .map_err(to_command_error)?

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,8 @@ async fn environment_status(state: tauri::State<'_, AppState>) -> Result<Environ
         has_deepgram_key: std::env::var("DEEPGRAM_API_KEY").is_ok(),
         has_anthropic_key: std::env::var("ANTHROPIC_API_KEY").is_ok(),
         has_deepseek_key: std::env::var("DEEPSEEK_API_KEY").is_ok(),
+        has_openai_key: std::env::var("OPENAI_API_KEY").is_ok(),
+        has_gemini_key: std::env::var("GEMINI_API_KEY").is_ok(),
         llm_provider,
         has_local_whisper_model,
         has_ollama,
@@ -461,6 +463,28 @@ async fn generate_candidates(
                 .or_else(|| std::env::var("OLLAMA_MODEL").ok())
                 .unwrap_or_else(|| "llama3.2".to_string());
             llm::detect_candidates_with_local_llm(&normalized, &model)
+                .await
+                .map_err(to_command_error)?
+        }
+        "openai" => {
+            let key = api_key
+                .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+                .ok_or_else(|| "Set OPENAI_API_KEY or supply OpenAI API Key to generate candidates.".to_string())?;
+            let model = model_name
+                .or_else(|| std::env::var("OPENAI_MODEL").ok())
+                .unwrap_or_else(|| "gpt-4o-mini".to_string());
+            llm::detect_candidates_with_openai(&normalized, &key, &model)
+                .await
+                .map_err(to_command_error)?
+        }
+        "gemini" => {
+            let key = api_key
+                .or_else(|| std::env::var("GEMINI_API_KEY").ok())
+                .ok_or_else(|| "Set GEMINI_API_KEY or supply Gemini API Key to generate candidates.".to_string())?;
+            let model = model_name
+                .or_else(|| std::env::var("GEMINI_MODEL").ok())
+                .unwrap_or_else(|| "gemini-1.5-flash".to_string());
+            llm::detect_candidates_with_gemini(&normalized, &key, &model)
                 .await
                 .map_err(to_command_error)?
         }
@@ -874,7 +898,7 @@ fn build_drawtext_filters(
         let mut font_option = String::new();
         for path in &font_paths {
             if std::path::Path::new(path).exists() {
-                font_option = format!("fontfile='{}':", path.replace(':', "\:"));
+                font_option = format!("fontfile='{}':", path.replace(':', r"\:"));
                 break;
             }
         }

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -86,6 +86,161 @@ Avoid rambling setup, context-dependent references, and pure filler. Return up t
     parse_candidate_json(&text, min_duration)
 }
 
+#[derive(Debug, Deserialize)]
+struct OpenAiMessage {
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiResponse {
+    choices: Vec<OpenAiChoice>,
+}
+
+pub async fn detect_candidates_with_openai(
+    transcript: &NormalizedTranscript,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<CandidateDraft>> {
+    let segments = compact_segments(&transcript.segments);
+    let prompt = format!(
+        "You are identifying the most viral moments and strongest short-form clip candidates from a long-form transcript. \
+For each candidate, the clip must be self-contained, starting with an extremely engaging hook within the first 3 seconds (to capture immediate attention on social feeds), \
+30-90 seconds long, and cut at clean sentence/thought boundaries. Favor highly shareable content: concrete stories, \
+strong opinions, emotional turns, surprising or counter-intuitive claims, clear payoffs, and high-energy/dramatic peaks. \
+Avoid rambling setup, context-dependent references, and pure filler. Return up to 10 candidates as JSON matching this schema: \
+{{\"candidates\":[{{\"start\":0.0,\"end\":0.0,\"score\":0.0,\"hook\":\"...\",\"rationale\":\"...\"}}]}}\n\nTranscript:\n{segments}"
+    );
+
+    let response = reqwest::Client::new()
+        .post("https://api.openai.com/v1/chat/completions")
+        .header("Authorization", format!("Bearer {api_key}"))
+        .json(&json!({
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+            "temperature": 0.2,
+            "response_format": {
+                "type": "json_object"
+            }
+        }))
+        .send()
+        .await
+        .context("calling OpenAI")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("OpenAI request failed ({status}): {body}"));
+    }
+
+    let res_body: OpenAiResponse = response.json().await.context("parsing OpenAI response")?;
+    let text = res_body
+        .choices
+        .first()
+        .map(|c| c.message.content.clone())
+        .ok_or_else(|| anyhow!("OpenAI response did not include choices content"))?;
+
+    let min_duration = if transcript.duration < 60.0 {
+        (transcript.duration * 0.5).max(5.0)
+    } else {
+        30.0
+    };
+    parse_candidate_json(&text, min_duration)
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiPart {
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiContent {
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiCandidate {
+    content: GeminiContent,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiResponse {
+    candidates: Vec<GeminiCandidate>,
+}
+
+pub async fn detect_candidates_with_gemini(
+    transcript: &NormalizedTranscript,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<CandidateDraft>> {
+    let segments = compact_segments(&transcript.segments);
+    let prompt = format!(
+        "You are identifying the most viral moments and strongest short-form clip candidates from a long-form transcript. \
+For each candidate, the clip must be self-contained, starting with an extremely engaging hook within the first 3 seconds (to capture immediate attention on social feeds), \
+30-90 seconds long, and cut at clean sentence/thought boundaries. Favor highly shareable content: concrete stories, \
+strong opinions, emotional turns, surprising or counter-intuitive claims, clear payoffs, and high-energy/dramatic peaks. \
+Avoid rambling setup, context-dependent references, and pure filler. Return up to 10 candidates as JSON matching this schema: \
+{{\"candidates\":[{{\"start\":0.0,\"end\":0.0,\"score\":0.0,\"hook\":\"...\",\"rationale\":\"...\"}}]}}\n\nTranscript:\n{segments}"
+    );
+
+    let url = format!("https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent");
+
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("x-goog-api-key", api_key)
+        .json(&json!({
+            "contents": [
+                {
+                    "parts": [
+                        { "text": prompt }
+                    ]
+                }
+            ],
+            "generationConfig": {
+                "temperature": 0.2,
+                "responseMimeType": "application/json"
+            }
+        }))
+        .send()
+        .await
+        .context("calling Gemini")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("Gemini request failed ({status}): {body}"));
+    }
+
+    let res_body: GeminiResponse = response.json().await.context("parsing Gemini response")?;
+    let text = res_body
+        .candidates
+        .into_iter()
+        .find_map(|candidate| {
+            candidate
+                .content
+                .parts
+                .into_iter()
+                .find_map(|part| part.text)
+        })
+        .ok_or_else(|| anyhow!("Gemini response did not include text content"))?;
+
+    let min_duration = if transcript.duration < 60.0 {
+        (transcript.duration * 0.5).max(5.0)
+    } else {
+        30.0
+    };
+    parse_candidate_json(&text, min_duration)
+}
+
 #[derive(Debug, Serialize)]
 struct ClaudeMessage<'a> {
     role: &'a str,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -9,6 +9,8 @@ pub struct EnvironmentStatus {
     pub has_deepgram_key: bool,
     pub has_anthropic_key: bool,
     pub has_deepseek_key: bool,
+    pub has_openai_key: bool,
+    pub has_gemini_key: bool,
     pub llm_provider: String,
     pub has_local_whisper_model: bool,
     pub has_ollama: bool,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,6 +32,8 @@ type EnvironmentStatus = {
   hasDeepgramKey: boolean;
   hasAnthropicKey: boolean;
   hasDeepseekKey: boolean;
+  hasOpenaiKey: boolean;
+  hasGeminiKey: boolean;
   llmProvider: string;
   hasLocalWhisperModel: boolean;
   hasOllama: boolean;
@@ -108,6 +110,14 @@ type BusyState =
   | "clipCount"
   | "cut";
 
+function cloudLlmLabel(engine: string): string {
+  if (engine === "claude") return "Claude";
+  if (engine === "deepseek") return "DeepSeek";
+  if (engine === "openai") return "OpenAI";
+  if (engine === "gemini") return "Gemini";
+  return engine;
+}
+
 function App() {
   const [environment, setEnvironment] = useState<EnvironmentStatus | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -125,8 +135,8 @@ function App() {
   const [transcriptionEngine, setTranscriptionEngine] = useState<"deepgram" | "local">(() => {
     return (localStorage.getItem("autoshorts_transcription_engine") as "deepgram" | "local") || "local";
   });
-  const [llmEngine, setLlmEngine] = useState<"claude" | "deepseek" | "local">(() => {
-    return (localStorage.getItem("autoshorts_llm_engine") as "claude" | "deepseek" | "local") || "local";
+  const [llmEngine, setLlmEngine] = useState<"claude" | "deepseek" | "local" | "openai" | "gemini">(() => {
+    return (localStorage.getItem("autoshorts_llm_engine") as "claude" | "deepseek" | "local" | "openai" | "gemini") || "local";
   });
   const [localLlmModel, setLocalLlmModel] = useState(() => {
     return localStorage.getItem("autoshorts_local_llm_model") || "llama3.2";
@@ -139,6 +149,18 @@ function App() {
   });
   const [deepseekKey, setDeepseekKey] = useState(() => {
     return localStorage.getItem("autoshorts_deepseek_key") || "";
+  });
+  const [openaiKey, setOpenaiKey] = useState(() => {
+    return localStorage.getItem("autoshorts_openai_key") || "";
+  });
+  const [geminiKey, setGeminiKey] = useState(() => {
+    return localStorage.getItem("autoshorts_gemini_key") || "";
+  });
+  const [openaiModel, setOpenaiModel] = useState(() => {
+    return localStorage.getItem("autoshorts_openai_model") || "gpt-4o-mini";
+  });
+  const [geminiModel, setGeminiModel] = useState(() => {
+    return localStorage.getItem("autoshorts_gemini_model") || "gemini-1.5-flash";
   });
 
   const [downloadingModelName, setDownloadingModelName] = useState<string | null>(null);
@@ -170,6 +192,8 @@ function App() {
   const canUseCloudKey = environment?.hasDeepgramKey || deepgramKey.trim().length > 0;
   const canUseClaude = environment?.hasAnthropicKey || anthropicKey.trim().length > 0;
   const canUseDeepseek = environment?.hasDeepseekKey || deepseekKey.trim().length > 0;
+  const canUseOpenai = environment?.hasOpenaiKey || openaiKey.trim().length > 0;
+  const canUseGemini = environment?.hasGeminiKey || geminiKey.trim().length > 0;
 
   const canTranscribe = transcriptionEngine === "local"
     ? Boolean(environment?.hasLocalWhisperModel)
@@ -177,7 +201,10 @@ function App() {
 
   const canUseActiveLlm = llmEngine === "local"
     ? Boolean(environment?.hasOllama)
-    : (llmEngine === "claude" ? canUseClaude : canUseDeepseek);
+    : llmEngine === "claude" ? canUseClaude
+    : llmEngine === "deepseek" ? canUseDeepseek
+    : llmEngine === "openai" ? canUseOpenai
+    : canUseGemini;
 
   useEffect(() => {
     void refresh();
@@ -212,6 +239,22 @@ function App() {
   useEffect(() => {
     localStorage.setItem("autoshorts_deepseek_key", deepseekKey);
   }, [deepseekKey]);
+
+  useEffect(() => {
+    localStorage.setItem("autoshorts_openai_key", openaiKey);
+  }, [openaiKey]);
+
+  useEffect(() => {
+    localStorage.setItem("autoshorts_gemini_key", geminiKey);
+  }, [geminiKey]);
+
+  useEffect(() => {
+    localStorage.setItem("autoshorts_openai_model", openaiModel);
+  }, [openaiModel]);
+
+  useEffect(() => {
+    localStorage.setItem("autoshorts_gemini_model", geminiModel);
+  }, [geminiModel]);
 
   const pullModelDirectly = async (modelName: string) => {
     setDownloadingModelName(modelName);
@@ -331,12 +374,13 @@ function App() {
         return;
       }
     } else {
-      const activeKey = llmEngine === "claude" ? anthropicKey : deepseekKey;
-      const hasActiveKey = llmEngine === "claude"
-        ? (env.hasAnthropicKey || activeKey.trim().length > 0)
-        : (env.hasDeepseekKey || activeKey.trim().length > 0);
+      const hasActiveKey =
+        llmEngine === "claude" ? (env.hasAnthropicKey || anthropicKey.trim().length > 0)
+        : llmEngine === "deepseek" ? (env.hasDeepseekKey || deepseekKey.trim().length > 0)
+        : llmEngine === "openai" ? (env.hasOpenaiKey || openaiKey.trim().length > 0)
+        : (env.hasGeminiKey || geminiKey.trim().length > 0);
       if (!hasActiveKey) {
-        setError(`Transcription complete. ${llmEngine === "claude" ? "Claude" : "DeepSeek"} API Key is missing. Please add it in settings to analyze viral moments.`);
+        setError(`Transcription complete. ${cloudLlmLabel(llmEngine)} API Key is missing. Please add it in settings to analyze viral moments.`);
         return;
       }
     }
@@ -359,12 +403,12 @@ function App() {
     // 2. LLM Moments
     try {
       setBusy("moments");
-      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
+      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : llmEngine === "deepseek" ? deepseekKey.trim() : llmEngine === "openai" ? openaiKey.trim() : llmEngine === "gemini" ? geminiKey.trim() : "";
       await invoke<Candidate[]>("generate_candidates", {
         projectId,
         apiKey: activeKey || null,
         provider: llmEngine,
-        modelName: llmEngine === "local" ? localLlmModel.trim() : null,
+        modelName: llmEngine === "local" ? localLlmModel.trim() : llmEngine === "openai" ? (openaiModel.trim() || null) : llmEngine === "gemini" ? (geminiModel.trim() || null) : null,
         allowDemo: false,
       });
       await refresh(projectId);
@@ -440,13 +484,13 @@ function App() {
   async function moments(allowDemo: boolean) {
     if (!detail) return;
     await run("moments", async () => {
-      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
+      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : llmEngine === "deepseek" ? deepseekKey.trim() : llmEngine === "openai" ? openaiKey.trim() : llmEngine === "gemini" ? geminiKey.trim() : "";
       try {
         await invoke<Candidate[]>("generate_candidates", {
           projectId: detail.project.id,
           apiKey: activeKey || null,
           provider: llmEngine,
-          modelName: llmEngine === "local" ? localLlmModel.trim() : null,
+          modelName: llmEngine === "local" ? localLlmModel.trim() : llmEngine === "openai" ? (openaiModel.trim() || null) : llmEngine === "gemini" ? (geminiModel.trim() || null) : null,
           allowDemo,
         });
         await refresh(detail.project.id);
@@ -531,9 +575,13 @@ function App() {
         setDeepgramKey={setDeepgramKey}
         setAnthropicKey={setAnthropicKey}
         setDeepseekKey={setDeepseekKey}
+        setOpenaiKey={setOpenaiKey}
+        setGeminiKey={setGeminiKey}
         deepgramKey={deepgramKey}
         anthropicKey={anthropicKey}
         deepseekKey={deepseekKey}
+        openaiKey={openaiKey}
+        geminiKey={geminiKey}
         refreshEnv={() => refresh()}
       />
     );
@@ -627,11 +675,13 @@ function App() {
                       <span>LLM Engine</span>
                       <select
                         value={llmEngine}
-                        onChange={(event) => setLlmEngine(event.target.value as "claude" | "deepseek" | "local")}
+                        onChange={(event) => setLlmEngine(event.target.value as "claude" | "deepseek" | "local" | "openai" | "gemini")}
                       >
                         <option value="local">Ollama (Offline Local)</option>
                         <option value="claude">Claude (Cloud)</option>
                         <option value="deepseek">DeepSeek (Cloud)</option>
+                        <option value="openai">OpenAI (Cloud)</option>
+                        <option value="gemini">Gemini (Cloud)</option>
                       </select>
                     </label>
                     {transcriptionEngine === "deepgram" && (
@@ -666,6 +716,50 @@ function App() {
                           type="password"
                         />
                       </label>
+                    )}
+                    {llmEngine === "openai" && (
+                      <>
+                        <label>
+                          <span>OpenAI API Key</span>
+                          <input
+                            value={openaiKey}
+                            onChange={(event) => setOpenaiKey(event.target.value)}
+                            placeholder={environment?.hasOpenaiKey ? "Loaded from env" : "Optional (OpenAI API Key)"}
+                            type="password"
+                          />
+                        </label>
+                        <label>
+                          <span>OpenAI Model</span>
+                          <input
+                            value={openaiModel}
+                            onChange={(event) => setOpenaiModel(event.target.value)}
+                            placeholder="e.g. gpt-4o-mini, gpt-4o"
+                            type="text"
+                          />
+                        </label>
+                      </>
+                    )}
+                    {llmEngine === "gemini" && (
+                      <>
+                        <label>
+                          <span>Gemini API Key</span>
+                          <input
+                            value={geminiKey}
+                            onChange={(event) => setGeminiKey(event.target.value)}
+                            placeholder={environment?.hasGeminiKey ? "Loaded from env" : "Optional (Gemini API Key)"}
+                            type="password"
+                          />
+                        </label>
+                        <label>
+                          <span>Gemini Model</span>
+                          <input
+                            value={geminiModel}
+                            onChange={(event) => setGeminiModel(event.target.value)}
+                            placeholder="e.g. gemini-1.5-flash, gemini-1.5-pro"
+                            type="text"
+                          />
+                        </label>
+                      </>
                     )}
                     {llmEngine === "local" && (
                       <label>
@@ -772,7 +866,7 @@ function App() {
                     <div className="api-warning">
                       {llmEngine === "local"
                         ? "⚠️ Ollama local server is not running at http://localhost:11434. Moment detection will not work."
-                        : `⚠️ ${llmEngine === "claude" ? "Claude" : "DeepSeek"} API Key is missing. Viral moment identification will not work. Please add your key in API Settings.`}
+                        : `⚠️ ${cloudLlmLabel(llmEngine)} API Key is missing. Viral moment identification will not work. Please add your key in API Settings.`}
                     </div>
                   )}
 
@@ -924,6 +1018,8 @@ function App() {
             <span className={`indicator ${canUseCloudKey ? "active" : ""}`} title="Deepgram Key status">Deepgram</span>
             <span className={`indicator ${canUseClaude ? "active" : ""}`} title="Claude Key status">Claude</span>
             <span className={`indicator ${canUseDeepseek ? "active" : ""}`} title="DeepSeek Key status">DeepSeek</span>
+            <span className={`indicator ${canUseOpenai ? "active" : ""}`} title="OpenAI Key status">OpenAI</span>
+            <span className={`indicator ${canUseGemini ? "active" : ""}`} title="Gemini Key status">Gemini</span>
           </div>
         </div>
       </footer>
@@ -1096,14 +1192,18 @@ interface OnboardingProps {
   environment: EnvironmentStatus | null;
   onComplete: () => void;
   setTranscriptionEngine: (engine: "deepgram" | "local") => void;
-  setLlmEngine: (engine: "claude" | "deepseek" | "local") => void;
+  setLlmEngine: (engine: "claude" | "deepseek" | "local" | "openai" | "gemini") => void;
   setLocalLlmModel: (model: string) => void;
   setDeepgramKey: (key: string) => void;
   setAnthropicKey: (key: string) => void;
   setDeepseekKey: (key: string) => void;
+  setOpenaiKey: (key: string) => void;
+  setGeminiKey: (key: string) => void;
   deepgramKey: string;
   anthropicKey: string;
   deepseekKey: string;
+  openaiKey: string;
+  geminiKey: string;
   refreshEnv: () => Promise<void>;
 }
 
@@ -1116,9 +1216,13 @@ function Onboarding({
   setDeepgramKey,
   setAnthropicKey,
   setDeepseekKey,
+  setOpenaiKey,
+  setGeminiKey,
   deepgramKey: initialDeepgramKey,
   anthropicKey: initialAnthropicKey,
   deepseekKey: initialDeepseekKey,
+  openaiKey: initialOpenaiKey,
+  geminiKey: initialGeminiKey,
   refreshEnv,
 }: OnboardingProps) {
   const [setupMode, setSetupMode] = useState<"choose" | "local" | "cloud" | "downloading">("choose");
@@ -1127,6 +1231,8 @@ function Onboarding({
   const [dgKey, setDgKey] = useState(initialDeepgramKey);
   const [antKey, setAntKey] = useState(initialAnthropicKey);
   const [dsKey, setDsKey] = useState(initialDeepseekKey);
+  const [oaKey, setOaKey] = useState(initialOpenaiKey);
+  const [gemKey, setGemKey] = useState(initialGeminiKey);
   
   const [downloadStatus, setDownloadStatus] = useState("Initializing download...");
   const [downloadProgress, setDownloadProgress] = useState(0);
@@ -1146,8 +1252,8 @@ function Onboarding({
       setError("Deepgram API Key is required for cloud mode.");
       return;
     }
-    if (!antKey.trim() && !dsKey.trim()) {
-      setError("Please provide at least one LLM Key (Claude or DeepSeek).");
+    if (!antKey.trim() && !dsKey.trim() && !oaKey.trim() && !gemKey.trim()) {
+      setError("Please provide at least one LLM Key (Claude, DeepSeek, OpenAI, or Gemini).");
       return;
     }
     
@@ -1166,8 +1272,18 @@ function Onboarding({
       setDeepseekKey(dsKey.trim());
       localStorage.setItem("autoshorts_deepseek_key", dsKey.trim());
       localStorage.setItem("autoshorts_llm_engine", "deepseek");
+    } else if (oaKey.trim()) {
+      setLlmEngine("openai");
+      setOpenaiKey(oaKey.trim());
+      localStorage.setItem("autoshorts_openai_key", oaKey.trim());
+      localStorage.setItem("autoshorts_llm_engine", "openai");
+    } else if (gemKey.trim()) {
+      setLlmEngine("gemini");
+      setGeminiKey(gemKey.trim());
+      localStorage.setItem("autoshorts_gemini_key", gemKey.trim());
+      localStorage.setItem("autoshorts_llm_engine", "gemini");
     }
-    
+
     localStorage.setItem("autoshorts_onboarded", "true");
     onComplete();
   };
@@ -1404,14 +1520,34 @@ function Onboarding({
 
               <div className="input-group">
                 <label>DeepSeek API Key</label>
-                <input 
-                  type="password" 
-                  value={dsKey} 
+                <input
+                  type="password"
+                  value={dsKey}
                   onChange={(e) => setDsKey(e.target.value)}
                   placeholder="Insert your DeepSeek API Key (alternative moment detection)"
                 />
               </div>
-              <p className="form-help">* Deepgram Key + at least one LLM Key (Claude or DeepSeek) is required.</p>
+
+              <div className="input-group">
+                <label>OpenAI API Key</label>
+                <input
+                  type="password"
+                  value={oaKey}
+                  onChange={(e) => setOaKey(e.target.value)}
+                  placeholder="Insert your OpenAI API Key (moment detection)"
+                />
+              </div>
+
+              <div className="input-group">
+                <label>Gemini API Key</label>
+                <input
+                  type="password"
+                  value={gemKey}
+                  onChange={(e) => setGemKey(e.target.value)}
+                  placeholder="Insert your Google Gemini API Key (moment detection)"
+                />
+              </div>
+              <p className="form-help">* Deepgram Key + at least one LLM Key (Claude, DeepSeek, OpenAI, or Gemini) is required.</p>
             </div>
 
             <div className="onboarding-actions">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -160,7 +160,7 @@ function App() {
     return localStorage.getItem("autoshorts_openai_model") || "gpt-4o-mini";
   });
   const [geminiModel, setGeminiModel] = useState(() => {
-    return localStorage.getItem("autoshorts_gemini_model") || "gemini-1.5-flash";
+    return localStorage.getItem("autoshorts_gemini_model") || "gemini-2.5-flash";
   });
 
   const [downloadingModelName, setDownloadingModelName] = useState<string | null>(null);
@@ -755,7 +755,7 @@ function App() {
                           <input
                             value={geminiModel}
                             onChange={(event) => setGeminiModel(event.target.value)}
-                            placeholder="e.g. gemini-1.5-flash, gemini-1.5-pro"
+                            placeholder="e.g. gemini-2.5-flash, gemini-2.5-pro"
                             type="text"
                           />
                         </label>


### PR DESCRIPTION
 Adds **OpenAI** and **Google Gemini** as cloud moment-detection providers, alongside the existing DeepSeek / Claude / Ollama.

  Part of #5. Starting with these two; Groq, OpenRouter, and xAI can follow the same pattern in later PRs.

  ## Changes

  **Backend (`src-tauri/`)**
  - `llm.rs`: new `detect_candidates_with_openai` and `detect_candidates_with_gemini`, following the existing per-provider pattern (own response
  structs, shared `compact_segments` + `parse_candidate_json` helpers, same prompt).
  - `lib.rs`: `"openai"` / `"gemini"` arms in `generate_candidates` (key + model resolved from arg → env → default), and `has_openai_key` /
  `has_gemini_key` in `environment_status`.
  - `models.rs`: two new `EnvironmentStatus` fields.
  - `.env.example`: `OPENAI_API_KEY`, `GEMINI_API_KEY`.

  **Frontend (`src/main.tsx`)**
  - OpenAI / Gemini in the LLM Engine dropdown, onboarding cloud form, and status bar.
  - Per-provider API key + free-text model selection, persisted to `localStorage`.
  - Key/model threaded through the `generate_candidates` calls; provider-aware warning labels.

  **Also:** fixes an invalid `"\:"` string escape in `build_drawtext_filters` (`lib.rs`) that failed to compile (`unknown character escape`) — a
  `r"\:"` raw string. Needed for the crate to build.

  ## Providers / defaults
  - OpenAI: `POST /v1/chat/completions`, Bearer auth, JSON mode. Default model `gpt-4o-mini`.
  - Gemini: `generateContent`, `x-goog-api-key`, `responseMimeType: application/json`. Default model `gemini-2.5-flash`.

  ## Testing
  - `cargo check` — passes
  - `npm run build` (tsc + vite) — passes
  - Manual: Settings → pick OpenAI/Gemini → enter key + model → Import → Transcribe → Find Viral Moments returns candidates.

  ## Notes
  - Keys stored in `localStorage` (matches existing app behavior).
  - Model selection is a free-text field (like the existing Ollama model input), so new models don't require a code change.