### PR TITLE
fix: pass API key for gemini/openai/openrouter in generate_candidates

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -408,7 +408,12 @@ function App() {
     // 2. LLM Moments
     try {
       setBusy("moments");
-      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
+      const activeKey =
+        llmEngine === "claude" ? anthropicKey.trim() :
+          llmEngine === "deepseek" ? deepseekKey.trim() :
+            llmEngine === "gemini" ? geminiKey.trim() :
+              llmEngine === "openai" ? openaiKey.trim() :
+                llmEngine === "openrouter" ? openrouterKey.trim() : "";
       await invoke<Candidate[]>("generate_candidates", {
         projectId,
         apiKey: activeKey || null,
@@ -489,7 +494,12 @@ function App() {
   async function moments(allowDemo: boolean) {
     if (!detail) return;
     await run("moments", async () => {
-      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
+      const activeKey =
+        llmEngine === "claude" ? anthropicKey.trim() :
+          llmEngine === "deepseek" ? deepseekKey.trim() :
+            llmEngine === "gemini" ? geminiKey.trim() :
+              llmEngine === "openai" ? openaiKey.trim() :
+                llmEngine === "openrouter" ? openrouterKey.trim() : "";
       try {
         await invoke<Candidate[]>("generate_candidates", {
           projectId: detail.project.id,


### PR DESCRIPTION
## Bug

Selecting **Gemini**, **OpenAI**, or **OpenRouter** as the LLM provider in Settings and entering an API key there has no effect on moment detection — it still fails with:

```
Set OPENROUTER_API_KEY or supply OpenRouter API Key to generate candidates.
```

(or the equivalent for `GEMINI_API_KEY` / `OPENAI_API_KEY`), even though the key is set in the UI, and even though the `.env` var isn't set at all.

## Root cause

In `src/main.tsx`, both call sites of `generate_candidates` (in `confirmImport()` and `moments()`) resolve the outgoing `apiKey` with:

```ts
const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
```

This only handles `claude` and `deepseek`; for `gemini`, `openai`, and `openrouter` it silently falls through to `""` → sent as `apiKey: null` → the Rust side (`lib.rs`, `generate_candidates`) then only has the env var to fall back on, and errors if it isn't set.

Note `runAutoPipeline()` already has the correct full mapping a few lines above (used just for the pre-flight "is a key configured" check), it just was never mirrored into the two actual `invoke("generate_candidates", ...)` calls.

## Fix

Mirror the same per-provider key mapping used in `runAutoPipeline()` into both `generate_candidates` call sites:

```ts
const activeKey =
  llmEngine === "claude" ? anthropicKey.trim() :
    llmEngine === "deepseek" ? deepseekKey.trim() :
      llmEngine === "gemini" ? geminiKey.trim() :
        llmEngine === "openai" ? openaiKey.trim() :
          llmEngine === "openrouter" ? openrouterKey.trim() : "";
```

## Test plan

Ran into this myself with an OpenRouter key set only in Settings (no `.env`) — reading through the code confirmed `activeKey` was resolving to `""` for the `openrouter` case, which matched the symptom exactly. The fix just mirrors the mapping already used (and working) in `runAutoPipeline()` a few lines above onto the two call sites that were missing it, so the logic itself isn't new/untested, just newly applied in these two spots. I have not personally re-run the full pipeline end-to-end against Gemini/OpenAI/OpenRouter after applying the fix to confirm candidate generation succeeds — flagging that in case a maintainer wants to verify before merging.