### PR TITLE
Fix hardcoded DeepSeek model causing 400 errors (#33)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -487,7 +487,7 @@ async fn generate_candidates(
             let key = api_key
                 .or_else(|| std::env::var("DEEPSEEK_API_KEY").ok())
                 .ok_or_else(|| "Set DEEPSEEK_API_KEY or supply DeepSeek API Key to generate candidates.".to_string())?;
-            llm::detect_candidates_with_deepseek(&normalized, &key)
+            llm::detect_candidates_with_deepseek(&normalized, &key, model_name.as_deref())
                 .await
                 .map_err(to_command_error)?
         }

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -33,6 +33,7 @@ struct DeepseekResponse {
 pub async fn detect_candidates_with_deepseek(
     transcript: &NormalizedTranscript,
     api_key: &str,
+    model_name: Option<&str>,
 ) -> Result<Vec<CandidateDraft>> {
     let segments = compact_segments(&transcript.segments);
     let prompt = format!(
@@ -44,11 +45,18 @@ Avoid rambling setup, context-dependent references, and pure filler. Return up t
 {{\"candidates\":[{{\"start\":0.0,\"end\":0.0,\"score\":0.0,\"hook\":\"...\",\"rationale\":\"...\"}}]}}\n\nTranscript:\n{segments}"
     );
 
+    let default_model = "deepseek-chat".to_string();
+    let model = model_name
+        .filter(|m| !m.trim().is_empty())
+        .map(|m| m.trim().to_string())
+        .or_else(|| std::env::var("DEEPSEEK_MODEL").ok().filter(|m| !m.trim().is_empty()))
+        .unwrap_or(default_model);
+
     let response = reqwest::Client::new()
         .post("https://api.deepseek.com/chat/completions")
         .header("Authorization", format!("Bearer {api_key}"))
         .json(&json!({
-            "model": "deepseek-chat",
+            "model": model,
             "messages": [
                 {
                     "role": "user",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -143,6 +143,9 @@ function App() {
   const [deepseekKey, setDeepseekKey] = useState(() => {
     return localStorage.getItem("autoshorts_deepseek_key") || "";
   });
+  const [deepseekModel, setDeepseekModel] = useState(() => {
+    return localStorage.getItem("autoshorts_deepseek_model") || "";
+  });
   const [geminiKey, setGeminiKey] = useState(() => {
     return localStorage.getItem("autoshorts_gemini_key") || "";
   });
@@ -235,6 +238,10 @@ function App() {
   useEffect(() => {
     localStorage.setItem("autoshorts_deepseek_key", deepseekKey);
   }, [deepseekKey]);
+
+  useEffect(() => {
+    localStorage.setItem("autoshorts_deepseek_model", deepseekModel);
+  }, [deepseekModel]);
 
   useEffect(() => {
     localStorage.setItem("autoshorts_gemini_key", geminiKey);
@@ -413,7 +420,7 @@ function App() {
         projectId,
         apiKey: activeKey || null,
         provider: llmEngine,
-        modelName: llmEngine === "local" ? localLlmModel.trim() : null,
+        modelName: llmEngine === "local" ? localLlmModel.trim() : (llmEngine === "deepseek" ? (deepseekModel.trim() || null) : null),
         allowDemo: false,
       });
       await refresh(projectId);
@@ -495,7 +502,7 @@ function App() {
           projectId: detail.project.id,
           apiKey: activeKey || null,
           provider: llmEngine,
-          modelName: llmEngine === "local" ? localLlmModel.trim() : null,
+          modelName: llmEngine === "local" ? localLlmModel.trim() : (llmEngine === "deepseek" ? (deepseekModel.trim() || null) : null),
           allowDemo,
         });
         await refresh(detail.project.id);
@@ -707,15 +714,26 @@ function App() {
                       </label>
                     )}
                     {llmEngine === "deepseek" && (
-                      <label>
-                        <span>DeepSeek API Key</span>
-                        <input
-                          value={deepseekKey}
-                          onChange={(event) => setDeepseekKey(event.target.value)}
-                          placeholder={environment?.hasDeepseekKey ? "Loaded from env" : "Optional (DeepSeek API Key)"}
-                          type="password"
-                        />
-                      </label>
+                      <>
+                        <label>
+                          <span>DeepSeek API Key</span>
+                          <input
+                            value={deepseekKey}
+                            onChange={(event) => setDeepseekKey(event.target.value)}
+                            placeholder={environment?.hasDeepseekKey ? "Loaded from env" : "Optional (DeepSeek API Key)"}
+                            type="password"
+                          />
+                        </label>
+                        <label>
+                          <span>DeepSeek Model</span>
+                          <input
+                            value={deepseekModel}
+                            onChange={(event) => setDeepseekModel(event.target.value)}
+                            placeholder="Optional (e.g. deepseek-chat, deepseek-v4-pro)"
+                            type="text"
+                          />
+                        </label>
+                      </>
                     )}
                     {llmEngine === "gemini" && (
                       <label>


### PR DESCRIPTION
### Fix hardcoded DeepSeek model causing 400 errors (#33)

#### Problem
DeepSeek API requests failed with `400 Bad Request` because the model parameter was hardcoded to `deepseek-chat`, which failed for endpoints requiring newer or custom model names (e.g. `deepseek-v4-pro`, `deepseek-v4-flash`).

#### Changes
- **Backend (`src-tauri/src/llm.rs` & `lib.rs`)**: Updated `detect_candidates_with_deepseek` to dynamically accept custom `model_name` inputs and fall back to the `DEEPSEEK_MODEL` environment variable before defaulting to `deepseek-chat`.
- **Frontend (`src/main.tsx`)**: Added a DeepSeek model configuration input field in the Settings Modal and wired `modelName` through `generate_candidates` IPC calls.

Closes #33 