### PR TITLE
Fix Gemini, OpenAI, and OpenRouter API keys not being sent from UI (#21)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -422,7 +422,12 @@ function App() {
     // 2. LLM Moments
     try {
       setBusy("moments");
-      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
+      const activeKey =
+        llmEngine === "claude" ? anthropicKey.trim() :
+          llmEngine === "deepseek" ? deepseekKey.trim() :
+            llmEngine === "gemini" ? geminiKey.trim() :
+              llmEngine === "openai" ? openaiKey.trim() :
+                llmEngine === "openrouter" ? openrouterKey.trim() : "";
       await invoke<Candidate[]>("generate_candidates", {
         projectId,
         apiKey: activeKey || null,
@@ -503,7 +508,12 @@ function App() {
   async function moments(allowDemo: boolean) {
     if (!detail) return;
     await run("moments", async () => {
-      const activeKey = llmEngine === "claude" ? anthropicKey.trim() : (llmEngine === "deepseek" ? deepseekKey.trim() : "");
+      const activeKey =
+        llmEngine === "claude" ? anthropicKey.trim() :
+          llmEngine === "deepseek" ? deepseekKey.trim() :
+            llmEngine === "gemini" ? geminiKey.trim() :
+              llmEngine === "openai" ? openaiKey.trim() :
+                llmEngine === "openrouter" ? openrouterKey.trim() : "";
       try {
         await invoke<Candidate[]>("generate_candidates", {
           projectId: detail.project.id,


### PR DESCRIPTION
### Fix Gemini, OpenAI, and OpenRouter API keys not being sent from UI (#21)

#### Problem
Entering a Gemini, OpenAI, or OpenRouter API key in the UI settings and running moment detection failed with `Set <PROVIDER>_API_KEY or supply <PROVIDER> API Key to generate candidates`.

#### Cause
`src/main.tsx` hardcoded `activeKey` evaluation to only handle `claude` and `deepseek`, causing keys typed into the UI for `gemini`, `openai`, and `openrouter` to be sent as `null`.

#### Fix
Updated `activeKey` ternary logic in `src/main.tsx` across both `generate_candidates` call sites to correctly include `geminiKey`, `openaiKey`, and `openrouterKey`.

Closes #21 